### PR TITLE
Talk Videos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: ruby
 rvm:
-    - 2.4.0
+    - 2.4
 
 cache:
   bundler: true

--- a/_src/_assets/styles/9984.scss
+++ b/_src/_assets/styles/9984.scss
@@ -41,6 +41,12 @@
     }
 }
 
+.section--videos {
+    .iframe-container {
+        border: .15rem solid $brand-01;
+    }
+}
+
 .section--venue {
     .location {
         margin-bottom: $spacer * 2;

--- a/_src/_assets/styles/9984.scss
+++ b/_src/_assets/styles/9984.scss
@@ -3,6 +3,7 @@
 @import 'fonts';
 @import 'typography';
 @import 'layout';
+@import 'media';
 @import 'sections';
 @import 'hero';
 @import 'header';

--- a/_src/_assets/styles/_media.scss
+++ b/_src/_assets/styles/_media.scss
@@ -1,0 +1,42 @@
+//
+// Responsive video
+//
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 35px;
+    height: 0;
+    overflow: hidden;
+
+    > iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}
+
+
+//
+// Responsive iframe
+//
+iframe {
+    max-width: 100%;
+}
+
+.iframe-container {
+    position: relative;
+    padding-bottom: 56.2%;
+    height: 0;
+    overflow: hidden;
+    margin: 0;
+
+    > iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/_src/_assets/styles/_speakers.scss
+++ b/_src/_assets/styles/_speakers.scss
@@ -98,6 +98,10 @@
     color: $brand-06;
 }
 
+.talk__video {
+    margin: $spacer (-$spacer);
+}
+
 //
 // Speaker list grid
 //

--- a/_src/_data/content-front.yml
+++ b/_src/_data/content-front.yml
@@ -42,6 +42,12 @@ speakers:
 # Heads up! Rest of the speakers section is dynamically created.
 # Content for each speaker can be edited in the respective .md file in _src/_speakers/
 
+# -----------------
+# Section: Videos
+# -----------------
+videos:
+    title: >
+        All talk videos
 
 # -----------------
 # Section: Location

--- a/_src/_layouts/speaker.html
+++ b/_src/_layouts/speaker.html
@@ -53,7 +53,7 @@ layout: base
                 </ul>
             </div>
 
-            {% if talk %}
+             {% if talk %}
                 <aside class="speaker__talk">
                     <h2 class="speaker__talk__title">{{ talk.type }} <em class="divider--9984">>></em> 9984</h2>
                     <div class="talk">
@@ -65,6 +65,13 @@ layout: base
                                 tba
                             {% endif %}
                         </div>
+                        {% if talk.youtube_id %}
+                            <div class="talk__video">
+                                <figure class="iframe-container">
+                                    <iframe width="640" height="480" src="https://www.youtube.com/embed/{{ talk.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+                                </figure>
+                            </div>
+                        {% endif %}
                         <div class="talk__content">
                             {{ talk.content | markdownify }}
                         </div>

--- a/_src/_talks/README.md
+++ b/_src/_talks/README.md
@@ -15,12 +15,14 @@ talk_id: building-the-future-from-our-heads-not-our-hands
 type: keynote
 title: Building the future from our heads, not our hands
 time: tba
+youtube_id: xxxxxxxx
 ---
 
 The early days of the commercial Internet were chaotic. The people who were most successful at creating value from the turmoil, both technologists and businesspeople alike, were those who had clear visions of making a future from the crude building blocks available to them, like a child dumping a box of Legos on the floor and building a dinosaur. Domain names and web sites were those blocks. What are they today?
 ```
 
  - `talk_id`: the id of the talk. Used to reference the talk with a speaker.
+ - `youtube_id`: the id of the video on YouTube. If set, will embed the video within the talk box on a speaker's page.
  - `type`: the type of talk, e.g. *keynote*. Will be output above the talk on speakers page.
  - `title`: the full title of the talk.
  - `time`: the scheduled time of the talk.

--- a/_src/_talks/artists-rights.md
+++ b/_src/_talks/artists-rights.md
@@ -2,6 +2,7 @@
 talk_id: artists-rights
 type: talk
 title: Artists Rights in the Era of the Distributed Ledger
+youtube_id: OrhX_Oz-l-w
 ---
 
 DACS is a leading global rights management organization for visual artists. In designing new services for artists, DACS constantly engages with the transformations and disruptions to the digital agora, as such the implications of blockchain based technologies from both a practical and theoretical position are currently being explored. This presentation will cover some of the legal and conceptual challenges of exploring a new hallmark for bronze through to innovations in distribution and delivery of licenses and royalties.

--- a/_src/_talks/blockchain-ecology-state-and-anarchy.md
+++ b/_src/_talks/blockchain-ecology-state-and-anarchy.md
@@ -2,6 +2,7 @@
 talk_id: blockchain-ecology-state-and-anarchy
 type: keynote
 title: "Blockchain: Ecology, State and Anarchy"
+youtube_id: CjrGVIP9lPA
 ---
 
 Capitalism runs on imperfect information. When an object is traded its entire context is reduced to price. Blockchains could allow for richer value representations including the history of an object, its scientific composition and its embedded externalities like CO2 emissions or bad labor practices.

--- a/_src/_talks/building-the-future-from-our-heads-not-our-hands.md
+++ b/_src/_talks/building-the-future-from-our-heads-not-our-hands.md
@@ -2,6 +2,7 @@
 talk_id: building-the-future-from-our-heads-not-our-hands
 type: keynote
 title: Building the future from our heads, not our hands
+youtube_id: hDf3wP1LKGw
 ---
 
 The early days of the commercial Internet were chaotic. The people who were most successful at creating value from the turmoil, both technologists and businesspeople alike, were those who had clear visions of making a future from the crude building blocks available to them, like a child dumping a box of Legos on the floor and building a dinosaur. Domain names and web sites were those blocks.  What are they today?

--- a/_src/_talks/decentralized-licenses-server.md
+++ b/_src/_talks/decentralized-licenses-server.md
@@ -2,6 +2,7 @@
 talk_id: decentralized-licenses-server
 type: talk
 title: A Decentralized License Server for Digital Assets
+youtube_id: qJ6J-6tP1a8
 ---
 
 By 2019, more than 50% of all industries will price and package their offerings as services with flexible subscription or consumption-based pricing models. From manufacturers of connected devices in automotive to home automation and medical devices, everyone wants to generate recurring revenue via a software-based offering or service. To overcome the challenge of dealing with millions of devices, tons of data, trust and scalability, BigchainDB is our perfect fit to build the future of licensing. Join us on our journey of a community driven licensing framework.

--- a/_src/_talks/digital-human-rights.md
+++ b/_src/_talks/digital-human-rights.md
@@ -2,8 +2,9 @@
 talk_id: digital-human-rights
 type: talk
 title: Digital Human Rights - The Right to Encryption and Self-Sovereign Data
+youtube_id: r67q8ZFjsdA
 ---
 
-The advent of mass market computers and the Internet created a new operating system for a digital society. But the Internet we have today is broken. We do not own or control our data. Given the rising amount of public data about our day to day interactions, we need a new techno-constitutional discourse about privacy by design. 
+The advent of mass market computers and the Internet created a new operating system for a digital society. But the Internet we have today is broken. We do not own or control our data. Given the rising amount of public data about our day to day interactions, we need a new techno-constitutional discourse about privacy by design.
 
 It is time that we rethink our data structures and our constitutional right to privacy considering the realities of the data driven world powered by AI, blockchain and IoT.

--- a/_src/_talks/digital-product-memory-every-product-has-a-story.md
+++ b/_src/_talks/digital-product-memory-every-product-has-a-story.md
@@ -2,6 +2,7 @@
 talk_id: digital-product-memory-every-product-has-a-story
 type: talk
 title: "Digital Product Memory: Every Product Has a Story"
+youtube_id: jX3i9-qpoVA
 ---
 
 innogy’s Digital Product Memory project “Twin of Things” seeks to give every product a story. innogy’s Digital Product Memory project “Twin of Things” seeks to give every product a story. innogy has formed a unique and open IoT and supply chain ecosystem to bring this vision into reality. It provides the trusted layer for the digital twin of any object, enabling industry 4.0. The focus is on developing tools and applications for the IoT space, using a blockchain, based on BigchainDB’s decentralized database which acts as the guarantor of identity, authenticity and provenance. In partnership with other enterprises, innogy brings new ideas to life in order to demonstrate the capabilities and potential of blockchain as it relates to physical assets, objects, machines and devices through concrete real-world examples.

--- a/_src/_talks/introducing-the-industry-commons.md
+++ b/_src/_talks/introducing-the-industry-commons.md
@@ -2,6 +2,7 @@
 talk_id: introducing-the-industry-commons
 type: talk
 title: "Introducing the Industry Commons"
+youtube_id: 7kOqfB9GjYc
 ---
 
 TBA

--- a/_src/_talks/not-so-secret-future.md
+++ b/_src/_talks/not-so-secret-future.md
@@ -2,6 +2,7 @@
 talk_id: not-so-secret-future
 type: keynote
 title: The Not-So-Secret Future
+youtube_id: Q6eOIsEQIqg
 ---
 
 Ubiquitous smartphones. Mobile payment systems. Cameras everywhere. As our technological capacity has developed, our ability to maintain a semblance of privacy—never mind anonymity—has greatly decreased. This talk will remind listeners why privacy matters, and what we can do to protect it.

--- a/_src/_talks/opportunities-for-music.md
+++ b/_src/_talks/opportunities-for-music.md
@@ -2,6 +2,7 @@
 talk_id: opportunities-for-music
 type: talk
 title: Opportunities for Music Distribution on the Blockchain
+youtube_id: NxamXPBXtds
 ---
 
 Could digital file distribution, rights management and payment allocations be improved with blockchain technology? In this talk we'll learn how a system designed around a century's old technology is in dramatic need of a reboot. Find out about current developments in the space and see what lies ahead for the future of music distribution and decentralization technologies.

--- a/_src/index.html
+++ b/_src/index.html
@@ -61,6 +61,16 @@ front_page: true
     </div>
 </section>
 
+<section class="section section--videos">
+    <div class="row">
+        <h1 class="section__title">Videos</h1>
+
+        <figure class="iframe-container">
+            <iframe width="640" height="480" src="//www.youtube.com/embed/hDf3wP1LKGw?list=PLroYW5r9qQK8Pgqr3b5g1-vfZgX6oX4fR" frameborder="0" allowfullscreen></iframe>
+        </figure>
+    </div>
+</section>
+
 <section class="section section--venue" id="venue">
     <div class="row">
         <h1 class="section__title">{{ content.venue.title }}</h1>

--- a/_src/index.html
+++ b/_src/index.html
@@ -63,7 +63,7 @@ front_page: true
 
 <section class="section section--videos">
     <div class="row">
-        <h1 class="section__title">Videos</h1>
+        <h1 class="section__title">{{ content.videos.title }}</h1>
 
         <figure class="iframe-container">
             <iframe width="640" height="480" src="//www.youtube.com/embed/hDf3wP1LKGw?list=PLroYW5r9qQK8Pgqr3b5g1-vfZgX6oX4fR" frameborder="0" allowfullscreen></iframe>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.6.1",
     "browser-sync": ">=2.10.0",
     "concurrent-transform": "^1.0.0",
     "critical": "^0.9.1",
@@ -46,7 +46,7 @@
     "gulp-header": "^1.8.9",
     "gulp-htmlmin": "^3.0.0",
     "gulp-if": "^2.0.2",
-    "gulp-imagemin": "^3.3.0",
+    "gulp-imagemin": "^3.4.0",
     "gulp-include": "^2.0.2",
     "gulp-load-plugins": "^1.5.0",
     "gulp-rename": "^1.2.2",
@@ -60,10 +60,10 @@
     "gulp-util": "^3.0.6",
     "js-yaml": "^3.9.0",
     "request": "^2.81.0",
-    "stylelint": "^8.1.1",
+    "stylelint": "^8.2.0",
     "stylelint-config-bigchaindb": "^1.0.0",
     "stylelint-config-standard": "^17.0.0",
-    "uglify-es": "^3.0.28"
+    "uglify-es": "^3.1.6"
   },
   "engines": {
     "node": ">=7.0.0"


### PR DESCRIPTION
Allows connecting a talk and a YouTube video by setting `youtube_id` in a talks file. If set, will result in:

<img width="983" alt="screen shot 2017-11-01 at 10 13 28" src="https://user-images.githubusercontent.com/90316/32267955-57ae0eba-beed-11e7-81e1-f0932adcc5d6.png">

### Getting the YouTube video id

The value for the `youtube_id` key can be obtained from any YouTube url. 

E.g. in the above case the url of the video is `https://www.youtube.com/watch?v=CjrGVIP9lPA&t=7s`. Based on this, the id is the part after `v=` until the next `&`, so here `CjrGVIP9lPA`. That id is put as value in a talk file under `_src/_talks/`:

```yaml
---
talk_id: blockchain-ecology-state-and-anarchy
type: keynote
title: "Blockchain: Ecology, State and Anarchy"
youtube_id: CjrGVIP9lPA
---
```

Additionally, this PR adds a new videos section on the front page showing the 9984 playlist:

<img width="1040" alt="screen shot 2017-11-01 at 10 45 06" src="https://user-images.githubusercontent.com/90316/32269123-c38b6962-bef1-11e7-828b-1977ae6c15f2.png">
